### PR TITLE
Convert soft breaks into spaces

### DIFF
--- a/web-markdown/src/render.rs
+++ b/web-markdown/src/render.rs
@@ -229,7 +229,7 @@ where
             }
             Html(_) => panic!("html outside html block"),
             FootnoteReference(_) => Err(HtmlError::not_implemented("footnotes refs")),
-            SoftBreak => Ok(self.next()?),
+            SoftBreak => Ok(cx.el_text(" ".into())),
             HardBreak => Ok(self.cx.el_br()),
             Rule => Ok(cx.render_rule(range)),
             TaskListMarker(m) => Ok(cx.render_tasklist_marker(m, range)),


### PR DESCRIPTION
The [common mark spec](https://spec.commonmark.org/0.31.2/#soft-line-breaks) says:

> A conforming parser may render a soft line break in HTML either as a line ending or as a space.

Currently this library supports two choices, line ending or nothing. This does not match the spec, and results test spanning multiple lines getting concatenated together without spaces which makes the soft break mode unusable for many use-cases.

This change replaces the nothing case with a space to match the spec.