### PR TITLE
Fix out of bound index for short html content

### DIFF
--- a/web-markdown/src/render.rs
+++ b/web-markdown/src/render.rs
@@ -185,7 +185,7 @@ where
 fn can_be_custom_component(raw_html: &str) -> bool {
     let chars: Vec<_> = raw_html.trim().chars().collect();
     let len = chars.len();
-    if len == 0 {
+    if len < 3 {
         return false;
     };
     let (fst, middle, last) = (chars[0], &chars[1..len - 1], chars[len - 1]);


### PR DESCRIPTION
It is possible withing a block of html for a 1 or 2 character string to be passed to this function ( after the fix from https://github.com/rambip/rust-web-markdown/pull/9 ). This fixes a panic in that case.