### PR TITLE
When html does not use a custom component attribute name, leave it as html

### DIFF
--- a/dioxus-markdown/examples/custom-components/src/main.rs
+++ b/dioxus-markdown/examples/custom-components/src/main.rs
@@ -85,7 +85,9 @@ mod tests {
     // Adapted from https://dioxuslabs.com/learn/0.6/cookbook/testing/
     fn test_hook_simple(mut check: impl FnMut() + 'static) {
         fn mock_app() -> Element {
-            rsx! { div {} }
+            rsx! {
+                div {}
+            }
         }
 
         let vdom = VirtualDom::new(mock_app);
@@ -116,7 +118,7 @@ mod tests {
     /// Must be run in a Dioxus runtime
     fn components() -> CustomComponents {
         let mut components = CustomComponents::new();
-        components.register("X", |props| Ok(rsx! { "Content" }));
+        components.register("X", |_props| Ok(rsx! { "Content" }));
         components
     }
 
@@ -173,9 +175,7 @@ mod tests {
                     Markdown { src: "<X/><X/>", components: components() }
                 },
                 rsx! {
-                    p { style: "", class: "",
-                        "ContentContent"
-                    }
+                    p { style: "", class: "", "ContentContent" }
                 },
             )
         });
@@ -219,9 +219,7 @@ mod tests {
                 },
                 // TODO: this seems like it should either produce two Xs or error, but just gives 1
                 rsx! {
-                    p { style: "", class: "",
-                        "Content"
-                    }
+                    p { style: "", class: "", "Content" }
                 },
             )
         });
@@ -236,6 +234,49 @@ mod tests {
                 },
                 // TODO: this seems like it should either produce two Xs or error, but just gives 1
                 rsx! { "Content" },
+            )
+        });
+    }
+
+    #[test]
+    fn inline_html_like_as_text() {
+        test_hook_simple(|| {
+            assert_rsx_eq(
+                rsx! {
+                    // TODO: provide a way to opt into preserving html as text
+                    Markdown {
+                        src: "For some values of X, Y, and Z, assume X<Y and Y>Z",
+                        components: components(),
+                    }
+                },
+                rsx! {
+                    p { style: "", class: "",
+                        span { style: "", class: "",
+                            "For some values of X, Y, and Z, assume X<Y and Y>Z"
+                        }
+                    }
+                },
+            )
+        });
+    }
+
+    #[test]
+    fn inline_html_like_as_html() {
+        test_hook_simple(|| {
+            assert_rsx_eq(
+                rsx! {
+                    Markdown {
+                        src: "For some values of X, Y, and Z, assume X<Y and Y>Z",
+                        components: components(),
+                    }
+                },
+                rsx! {
+                    p { style: "", class: "",
+                        span { style: "", class: "", "For some values of X, Y, and Z, assume X" }
+                        span { style: "", class: "", dangerous_inner_html: "<Y and Y>" }
+                        span { style: "", class: "", "Z" }
+                    }
+                },
             )
         });
     }

--- a/web-markdown/src/component.rs
+++ b/web-markdown/src/component.rs
@@ -209,11 +209,11 @@ mod test {
             Ok(_) => panic!(),
             Err(CustomHtmlTagError {
                 name: Some(name),
-                message: _
+                message: _,
             }) => assert_eq!(name, "a"),
             Err(CustomHtmlTagError {
                 name: None,
-                message: _
+                message: _,
             }) => panic!(),
         }
     }


### PR DESCRIPTION
This fixes the issue noted in https://github.com/rambip/rust-web-markdown/issues/11#issuecomment-2860355178 where content like `For some values of X, Y, and Z, assume X<Y and Y>Z` gets turned into `For some values of X, Y, and Z, assume Xsyntax error: expected equal sign after attribute name Z`.

With this change, html which does not conform to the custom component syntax is preserved as html and not an error, as long as it does not have same name as a component.

Also included is a (failing) test for a future feature there non component html could be preserved as text to mitigate https://github.com/rambip/rust-web-markdown/issues/11