### PR TITLE
Revert "Add opt out for preserving html"

### DIFF
--- a/dioxus-markdown/examples/custom-components/src/main.rs
+++ b/dioxus-markdown/examples/custom-components/src/main.rs
@@ -243,17 +243,17 @@ mod tests {
         test_hook_simple(|| {
             assert_rsx_eq(
                 rsx! {
+                    // TODO: provide a way to opt into preserving html as text
                     Markdown {
                         src: "For some values of X, Y, and Z, assume X<Y and Y>Z",
                         components: components(),
-                        preserve_html: false,
                     }
                 },
                 rsx! {
                     p { style: "", class: "",
-                        span { style: "", class: "", "For some values of X, Y, and Z, assume X" }
-                        span { style: "", class: "", "<Y and Y>" }
-                        span { style: "", class: "", "Z" }
+                        span { style: "", class: "",
+                            "For some values of X, Y, and Z, assume X<Y and Y>Z"
+                        }
                     }
                 },
             )
@@ -268,17 +268,12 @@ mod tests {
                     Markdown {
                         src: "For some values of X, Y, and Z, assume X<Y and Y>Z",
                         components: components(),
-                        preserve_html: true,
                     }
                 },
                 rsx! {
                     p { style: "", class: "",
                         span { style: "", class: "", "For some values of X, Y, and Z, assume X" }
-                        span {
-                            style: "",
-                            class: "",
-                            dangerous_inner_html: "<Y and Y>",
-                        }
+                        span { style: "", class: "", dangerous_inner_html: "<Y and Y>" }
                         span { style: "", class: "", "Z" }
                     }
                 },

--- a/dioxus-markdown/src/lib.rs
+++ b/dioxus-markdown/src/lib.rs
@@ -55,12 +55,6 @@ pub struct MdProps {
     components: ReadOnlySignal<CustomComponents>,
 
     frontmatter: Option<Signal<String>>,
-
-    /// wether to preserve arbitrary html.
-    /// If true, content may inject unsafe html, which could be a security or privacy risk if the input comes from an untrusted source.
-    /// TODO: supporting a sanitized subset of html might be a better approach in the future.
-    #[props(default = true)]
-    preserve_html: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -214,19 +208,12 @@ impl<'src> Context<'src, 'static> for MdContext {
                 f.call(e)
             }
         };
-        let props = self.0();
-        if props.preserve_html {
         rsx! {
             span {
                 dangerous_inner_html: "{inner_html}",
                 style: "{style}",
                 class: "{class}",
-                    onclick,
-                }
-            }
-        } else {
-            rsx! {
-                span { style: "{style}", class: "{class}", onclick, "{inner_html}" }
+                onclick: onclick
             }
         }
     }


### PR DESCRIPTION
Reverts rambip/rust-web-markdown#15

I completely forgot the "format code" step. Can you run `cargo fmt` before I merge the PR ?