### PR TITLE
only include katex css runtime dependency if `maths` feature is configured

### DIFF
--- a/dioxus-markdown/src/lib.rs
+++ b/dioxus-markdown/src/lib.rs
@@ -1,4 +1,4 @@
-use web_framework_markdown::{markdown_component, CowStr, MarkdownProps, MATH_STYLE_SHEET_LINK};
+use web_framework_markdown::{markdown_component, CowStr, MarkdownProps};
 
 use std::collections::BTreeMap;
 
@@ -419,8 +419,13 @@ pub fn Markdown(props: MdProps) -> Element {
     let src: String = props.src.to_string();
     let signal: Signal<MdProps> = Signal::new(props);
     let child = markdown_component(MdContext(signal.into()), &src);
+    #[cfg(feature = "maths")]
     rsx! {
-        document::Style { href: MATH_STYLE_SHEET_LINK.href }
+        document::Style { href: web_framework_markdown::MATH_STYLE_SHEET_LINK.href }
+        {child}
+    }
+    #[cfg(not(feature = "maths"))]
+    rsx! {
         {child}
     }
 }

--- a/leptos-markdown/src/lib.rs
+++ b/leptos-markdown/src/lib.rs
@@ -1,6 +1,5 @@
 use web_framework_markdown::{
     markdown_component, Context, CowStr, ElementAttributes, HtmlElement, MarkdownProps, StyleLink,
-    MATH_STYLE_SHEET_LINK,
 };
 
 pub type MdComponentProps = web_framework_markdown::MdComponentProps<View>;
@@ -303,22 +302,26 @@ pub fn __Md(
 
 #[allow(non_snake_case)]
 pub fn Markdown(props: __MdProps) -> impl IntoView {
-    let StyleLink {
-        rel,
-        href,
-        integrity,
-        crossorigin,
-    } = MATH_STYLE_SHEET_LINK;
+    #[cfg(feature = "maths")]
+    {
+        let StyleLink {
+            rel,
+            href,
+            integrity,
+            crossorigin,
+        } = web_framework_markdown::MATH_STYLE_SHEET_LINK;
 
-    let document = document();
+        let document = document();
 
-    let link = document.create_element("link").unwrap();
+        let link = document.create_element("link").unwrap();
 
-    link.set_attribute("rel", rel).unwrap();
-    link.set_attribute("href", href).unwrap();
-    link.set_attribute("integrity", integrity).unwrap();
-    link.set_attribute("crossorigin", crossorigin).unwrap();
+        link.set_attribute("rel", rel).unwrap();
+        link.set_attribute("href", href).unwrap();
+        link.set_attribute("integrity", integrity).unwrap();
+        link.set_attribute("crossorigin", crossorigin).unwrap();
 
-    document.head().unwrap().append_child(&link).unwrap();
+        document.head().unwrap().append_child(&link).unwrap();
+    }
+
     move || markdown_component(&props, &props.src.get())
 }

--- a/yew-markdown/src/lib.rs
+++ b/yew-markdown/src/lib.rs
@@ -1,6 +1,5 @@
 use web_framework_markdown::{
     markdown_component, Context, CowStr, ElementAttributes, HtmlElement, MarkdownProps, StyleLink,
-    MATH_STYLE_SHEET_LINK,
 };
 
 use core::ops::Range;
@@ -320,22 +319,25 @@ pub struct Props {
 
 #[function_component]
 pub fn Markdown(props: &Props) -> Html {
-    let document = window().unwrap().document().unwrap();
+    #[cfg(feature = "maths")]
+    {
+        let document = window().unwrap().document().unwrap();
 
-    let link = document.create_element("link").unwrap();
+        let link = document.create_element("link").unwrap();
 
-    let StyleLink {
-        rel,
-        href,
-        integrity,
-        crossorigin,
-    } = MATH_STYLE_SHEET_LINK;
-    link.set_attribute("rel", rel).unwrap();
-    link.set_attribute("href", href).unwrap();
-    link.set_attribute("integrity", integrity).unwrap();
-    link.set_attribute("crossorigin", crossorigin).unwrap();
+        let StyleLink {
+            rel,
+            href,
+            integrity,
+            crossorigin,
+        } = web_framework_markdown::MATH_STYLE_SHEET_LINK;
+        link.set_attribute("rel", rel).unwrap();
+        link.set_attribute("href", href).unwrap();
+        link.set_attribute("integrity", integrity).unwrap();
+        link.set_attribute("crossorigin", crossorigin).unwrap();
 
-    document.head().unwrap().append_child(&link).unwrap();
+        document.head().unwrap().append_child(&link).unwrap();
+    }
 
     markdown_component(props, &props.src)
 }


### PR DESCRIPTION
Stumbled upon the katex css being pulled at runtime which I'd like to avoid. As far as I understand it this runtime dependency is only required if the `maths` feature is used. Likely should be seens as a breaking change though.

I only tested the dioxus adjustment as I don't have experience using the other frameworks but wanted to keep the setup consistent.
Please drop the other changes if you don't have the time to test them :)